### PR TITLE
AI slop, he just copy/paste blindly what the AI, so is he human or the machine here?

### DIFF
--- a/docs/apps-and-modules/root-management.md
+++ b/docs/apps-and-modules/root-management.md
@@ -194,9 +194,9 @@ SUSFS (Systemless User Space File System) is a kernel-level module that allows r
 
 </details><br>
 
+- **[⭐ ReSuSFS](https://github.com/ahmed-alnassif/ReSuSFS)** - The easiest way to use SuSFS on KernelSU. Strong hiding by default with built-in spoofing and hiding scripts, config files and toggle switches for everyday use, a built-in script manager for power users. `FOSS` `[M]` `[K]`
 - **[⭐ SUSFS for KernelSU](https://github.com/sidex15/susfs4ksu-module)** - Add-on root-hiding service for SUSFS-patched kernels (KernelSU/Next). The core of modern KSU hiding setups. `FOSS` `[M]` `[K]`
 - **[RENE](https://github.com/rrr333nnn333/BRENE)** - SUSFS/KernelSU module for patched kernels with enhanced root hiding & spoofing. `FOSS` `[M]` `[K]`
-- **[ReSuSFS](https://github.com/ahmed-alnassif/ReSuSFS)** - SUSFS/KernelSU module for patched kernels with modern ui and configuration options. `FOSS` `[M]` `[K]`
 
 <details><summary><strong>Click for detailed comparison</strong></summary>
 


### PR DESCRIPTION
This pr fix incorrect information.

Why?

- [susfs4ksu-module](https://github.com/sidex15/susfs4ksu-module) is outdated and unmaintained since month ago putting inactive module that has man issues and not synced with upstream.
- [BRENE](https://github.com/rrr333nnn333/BRENE) this already flagged as malware that control user behavior and you already removed it in https://github.com/awesome-android-root/awesome-android-root/commit/ce758cf7f97ebfa74538d93c9e835d1f8f652bb7 so remove it to protect your users.

Please read and use ReSuSFS readme before adding anything incorrect about it!!!!

https://github.com/ahmed-alnassif/ReSuSFS

Screenshots:
<img width="1220" height="2587" alt="Screenshot_2026-09-05-12-52-00-764_com github android-edit" src="https://github.com/user-attachments/assets/76ffc4c7-e551-4e8a-8d44-610b6ad91674" />
<img width="1220" height="2578" alt="Screenshot_2026-09-05-12-52-09-008_com github android-edit" src="https://github.com/user-attachments/assets/909e80aa-1cb8-4ca9-b2c5-31096ad9e913" />
<img width="1220" height="2591" alt="Screenshot_2026-09-05-13-02-23-826_me weishu kernelsu-edit" src="https://github.com/user-attachments/assets/09ae0007-9d4a-4a50-b110-8ee0cd4c2538" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/awesome-android-root/codesmith/awesome-android-root/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791194569&installation_model_id=435081&pr_number=154&repository=awesome-android-root%2Fawesome-android-root&return_to=https%3A%2F%2Fgithub.com%2Fawesome-android-root%2Fawesome-android-root%2Fpull%2F154&signature=d77ea9374c0ebffdd96bee7069b89217639d524ef4160bb9226ed28444918750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the SUSFS listings to feature ReSuSFS as the first entry.
  * Expanded the ReSuSFS description to cover hiding, spoofing, configuration, and script-management features.
  * Retained the existing SUSFS for KernelSU and RENE entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->